### PR TITLE
Add a developer route

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -5,4 +5,5 @@
 //= link channels/index.js
 //= link channels/consumer.js
 //= link channels/faker_channel.js
+//= link channels/developer_channel.js
 //= link_tree ../builds

--- a/app/channels/developer_channel.rb
+++ b/app/channels/developer_channel.rb
@@ -1,0 +1,9 @@
+class DeveloperChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "developer_channel"
+  end
+
+  def unsubscribed
+    stop_all_streams
+  end
+end

--- a/app/controllers/developer_controller.rb
+++ b/app/controllers/developer_controller.rb
@@ -1,0 +1,51 @@
+require "webdrivers"
+
+class DeveloperController < ApplicationController
+  def index
+  end
+
+  def runner
+    url = params[:url]
+    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+      "goog:chromeOptions": { args: ["headless", "disable-gpu", "user-agent=Analytics Robot"] },
+    )
+    driver = Selenium::WebDriver.for :chrome, capabilities: capabilities
+
+    driver.get url
+    accept_cookies(driver)
+    click_elements(driver)
+
+    events = driver.execute_script("return dataLayer")
+    ActionCable.server.broadcast "developer_channel", events
+    driver.quit
+  end
+
+private
+
+  def accept_cookies(driver)
+    begin
+      element = driver.find_element(:xpath, "//*[@data-accept-cookies='true']")
+      element.click unless element.nil?
+    rescue
+      puts "No GOV.UK cookies on page"
+    end
+  end
+
+  def click_elements(driver)
+    elements = driver.find_elements(:xpath, "//*[@data-ga4]")
+    elements.each do |element|
+      data_ga4 = JSON.parse(element.attribute("data-ga4"))
+      begin
+        if data_ga4["type"]  == "accordion"
+          %w[opened closed].each do |_state|
+            element.click
+          end
+        else
+          element.click
+        end
+      rescue
+        puts "Element [#{element.tag_name} - #{element.accessible_name}] is not interactable!"
+      end
+    end
+  end
+end

--- a/app/javascript/channels/developer_channel.js
+++ b/app/javascript/channels/developer_channel.js
@@ -1,0 +1,144 @@
+import consumer from 'channels/consumer'
+
+consumer.subscriptions.create('DeveloperChannel', {
+  connected () {
+    console.log('Connected to DeveloperChannel')
+  },
+
+  disconnected () {
+    console.log('Disconnected from DeveloperChannel')
+  },
+
+  received (data) {
+    const url = document.getElementById('url').value
+    const outputElement = document.getElementById('developer-output')
+
+    let events = {
+      event_data: [],
+      page_view: [],
+      search: [],
+      other: []
+    }
+
+    for (let i = 0; i < data.length; i++) {
+      if (data[i].event === 'event_data') {
+        events['event_data'].push(data[i])
+      } else if (data[i].event === 'page_view') {
+        events['page_view'].push(data[i])
+      } else if (data[i].event === 'search') {
+        events['search_results'].push(data[i])
+      } else {
+        events['other'].push(data[i])
+      }
+    }
+
+    outputElement.append(this.createSummary(events, data.length, url))
+
+    var that = this
+    Object.keys(events, that).forEach(function (key, index) {
+      var keyEvents = events[key]
+
+      outputElement.append(
+        that.createDetails(
+          that.createEventHeader(key, keyEvents.length),
+          that.prettyPrint(keyEvents)
+        )
+      )
+    })
+
+    outputElement.append(
+      this.createDetails('RAW DATA', this.prettyPrint(data))
+    )
+  },
+
+  createDetails (header, body) {
+    let details = document.createElement('details')
+    details.setAttribute('class', 'govuk-details')
+    details.setAttribute('data-module', 'govuk-details')
+
+    details.append(this.createDetailsHeader(header))
+    details.append(this.createDetailsBody(body))
+
+    return details
+  },
+
+  createDetailsHeader (header) {
+    let summary = document.createElement('summary')
+    summary.setAttribute('class', 'govuk-details__summary')
+
+    let span = document.createElement('span')
+    span.setAttribute('class', 'govuk-details__summary-text')
+    span.innerHTML = header
+
+    summary.append(span)
+
+    return summary
+  },
+
+  createDetailsBody (body) {
+    let div = document.createElement('div')
+    div.setAttribute('class', 'govuk-details__text')
+
+    let pre = document.createElement('pre')
+    let code = document.createElement('code')
+    code.innerHTML = this.prettyPrint(JSON.parse(body))
+
+    pre.append(code)
+    div.append(pre)
+
+    return div
+  },
+
+  createSummary (events, eventCount, url) {
+    let dl = document.createElement('dl')
+    dl.setAttribute('class', 'govuk-summary-list')
+
+    dl.append(this.createSummaryRow('URL', url))
+    dl.append(this.createSummaryRow('Total events', eventCount))
+
+    Object.keys(events).forEach(function (key) {
+      let div = document.createElement('div')
+      div.setAttribute('class', 'govuk-summary-list__row')
+
+      let dt = document.createElement('dt')
+      dt.setAttribute('class', 'govuk-summary-list__key')
+      dt.innerHTML = key
+
+      let dd = document.createElement('dd')
+      dd.setAttribute('class', 'govuk-summary-list__value')
+      dd.innerHTML = events[key].length
+
+      div.append(dt)
+      div.append(dd)
+      dl.append(div)
+    })
+
+    return dl
+  },
+
+  createSummaryRow (key, value) {
+    let div = document.createElement('div')
+    div.setAttribute('class', 'govuk-summary-list__row')
+
+    let dt = document.createElement('dt')
+    dt.setAttribute('class', 'govuk-summary-list__key')
+    dt.innerHTML = key
+
+    let dd = document.createElement('dd')
+    dd.setAttribute('class', 'govuk-summary-list__value')
+    dd.innerHTML = value
+
+    div.append(dt)
+    div.append(dd)
+
+    return div
+  },
+
+  createEventHeader (eventType, count) {
+    return eventType.toUpperCase() + ' events [' + count + ']'
+  },
+
+  prettyPrint (events) {
+    return JSON.stringify(events, undefined, 2)
+  }
+})

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,2 +1,3 @@
 // Import all the channels to be used by Action Cable
 import 'channels/faker_channel'
+import 'channels/developer_channel'

--- a/app/models/fake_events.rb
+++ b/app/models/fake_events.rb
@@ -10,9 +10,11 @@ class FakeEvents < GtmEventGenerator
 private
 
   def fake_events
+    # This is a problem - at this point we don't have a url!
+    accept_all_cookies("https://www.integration.publishing.service.gov.uk")
+
     if %w[pageviews random].include?(interaction_type)
       find_interaction_urls.each_with_index do |url, index|
-        accept_all_cookies(url) if index == 1
         iterations.to_i.times do
           get_url(url)
           output_event_data
@@ -23,7 +25,6 @@ private
       end
     else
       find_interaction_urls.each_with_index do |url, index|
-        accept_all_cookies(url) if index == 1
         iterations.to_i.times do
           get_url(url)
           clickables.each do |clickable|
@@ -85,7 +86,6 @@ private
   def get_url(url)
     url = environment_url(url, environment)
     url = ApplicationController.helpers.append_utm(url, interaction_type, environment)
-    puts "Calling: #{url}"
     driver.get url
   end
 end

--- a/app/views/developer/index.html.erb
+++ b/app/views/developer/index.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-width-container ">
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">Analytics Robot | Developer</h1>
+        <%= form_with url: runner_path, method: :post do |form| %>
+          <div class="govuk-form-group">
+            <%= form.label :url, class: "govuk-label" %>
+            <%= form.text_field :url, class: "govuk-input" %>
+          </div>
+
+          <%= form.submit "Process", class: "govuk-button" %>
+        <% end %>
+
+        <h2 class="govuk-heading-l">Output</h2>
+        <%= turbo_frame_tag id="developer-output" do %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,22 +1,47 @@
-<%= form_with url: fake_path, method: :post do |form| %>
-  <div class="govuk-form-group">
-    <%= form.label :environment, class: "govuk-label" %>
-    <%= form.select :environment, @environments, { selected: @environments.first }, { class: "govuk-select" } %>
-  </div>
+<div class="govuk-width-container ">
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Analytics Robot</h1>
+        <%= form_with url: fake_path, method: :post do |form| %>
+          <div class="govuk-form-group">
+            <%= form.label :environment, class: "govuk-label" %>
+            <%= form.select :environment, @environments, { selected: @environments.first }, { class: "govuk-select" } %>
+          </div>
 
-  <div class="govuk-form-group">
-    <%= form.label :interaction_type, class: "govuk-label" %>
-    <%= form.select :interaction_type, @interaction_types, { selected: @interaction_types.first }, { class: "govuk-select" } %>
-  </div>
+          <div class="govuk-form-group">
+            <%= form.label :interaction_type, class: "govuk-label" %>
+            <%= form.select :interaction_type, @interaction_types, { selected: @interaction_types.first }, { class: "govuk-select" } %>
+          </div>
 
-  <div class="govuk-form-group">
-    <%= form.label :iterations, class: "govuk-label" %>
-    <%= form.number_field :iterations, value: 1, class: "govuk-input govuk-input--width-10" %>
-  </div>
+          <div class="govuk-form-group">
+            <%= form.label :iterations, class: "govuk-label" %>
+            <%= form.number_field :iterations, value: 1, class: "govuk-input govuk-input--width-10" %>
+          </div>
 
-  <%= form.submit "Process", class: "govuk-button" %>
-<% end %>
+          <%= form.submit "Process", class: "govuk-button" %>
+        <% end %>
 
-<h2 class="govuk-heading-l">Output</h2>
-<%= turbo_frame_tag id="faker-output" do %>
-<% end %>
+        <h2 class="govuk-heading-l">Output</h2>
+        <%= turbo_frame_tag id="faker-output" do %>
+        <% end %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <ul class="govuk-list">
+          <li>
+            <%= link_to "Random [10]", fake_path(environment: "integration", interaction_type: "random", iterations: 10), data: { turbo_method: "post" }, class: "govuk-link" %>
+          </li>
+          <li>
+            <%= link_to "Random [100]", fake_path(environment: "integration", interaction_type: "random", iterations: 100), data: { turbo_method: "post" }, class: "govuk-link" %>
+          </li>
+          <li>
+            <hr>
+          </li>
+          <li>
+            <%= link_to "Developer", developer_path, class: "govuk-link" %>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,26 +64,7 @@
       </div>
     </header>
 
-    <div class="govuk-width-container ">
-      <main class="govuk-main-wrapper " id="main-content" role="main">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Analytics Robot</h1>
-            <%= yield %>
-          </div>
-          <div class="govuk-grid-column-one-third">
-            <ul class="govuk-list">
-              <li>
-                <%= link_to "Random [10]", fake_path(environment: "integration", interaction_type: "random", iterations: 10), data: { turbo_method: "post" }, class: "govuk-link" %>
-              </li>
-              <li>
-                <%= link_to "Random [100]", fake_path(environment: "integration", interaction_type: "random", iterations: 100), data: { turbo_method: "post" }, class: "govuk-link" %>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </main>
-    </div>
+    <%= yield %>
 
     <footer class="govuk-footer " role="contentinfo">
       <div class="govuk-width-container ">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
+  get "developer/index", as: "developer"
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 
   post "home/fake", as: "fake"
+  post "developer/runner", as: "runner"
   root "home#index"
 end

--- a/spec/requests/developer_spec.rb
+++ b/spec/requests/developer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Developers", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/developer/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/developer/index.html.erb_spec.rb
+++ b/spec/views/developer/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "developer/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Add a developer route which can take any URL (including localhost), find all GA4 elements on the page and click them all. Produce a suitable report.

Primarily, for use when developing, testing or adding new interactions.

## Screenshot

![screencapture-localhost-3000-developer-index-2022-11-07-10_11_13](https://user-images.githubusercontent.com/44037625/200289875-c11b6a37-dcc8-4597-9bcc-1c89799442e4.png)
